### PR TITLE
fix issue with trackpad scrolling

### DIFF
--- a/src/components/FullPage.js
+++ b/src/components/FullPage.js
@@ -104,9 +104,9 @@ class FullPage extends React.Component {
 
     const scrollDown = (e.wheelDelta || -e.deltaY || -e.detail) < 0;
     let activeSlide = this.state.activeSlide;
-    const trackPadScroll = e.deltaY > 0 && e.deltaY < 30 || e.deltaY < -30 && e.deltaY > 0;
-    
-    if (trackPadScroll) {
+    const isTrackPadScrolling = e.deltaY > 0 && e.deltaY < 30 || e.deltaY < -30 && e.deltaY > 0;
+
+    if (isTrackPadScrolling) {
       return false
     }
     if (scrollDown) {

--- a/src/components/FullPage.js
+++ b/src/components/FullPage.js
@@ -104,7 +104,11 @@ class FullPage extends React.Component {
 
     const scrollDown = (e.wheelDelta || -e.deltaY || -e.detail) < 0;
     let activeSlide = this.state.activeSlide;
-
+    const trackPadScroll = e.deltaY > 0 && e.deltaY < 30 || e.deltaY < -30 && e.deltaY > 0;
+    
+    if (trackPadScroll) {
+      return false
+    }
     if (scrollDown) {
       activeSlide++;
     } else {


### PR DESCRIPTION
When scrolling with trackpad or touchpad onScroll is triggered twice. This fixes the issue with the velocity that the trackpad has which triggers the event twice. Tested on windows trackpad and mac touchpad.