### PR TITLE
forward ref to <Slide />

### DIFF
--- a/src/components/Slide.jsx
+++ b/src/components/Slide.jsx
@@ -1,11 +1,11 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { forwardRef } from 'react';
 
-const Slide = (props) => (
-  <div {...props} style={{ ...props.style, height: '100%' }}>
+const Slide = forwardRef((props, forwardedRef) => (
+  <div ref={forwardedRef} {...props} style={{ ...props.style, height: '100%' }}>
     {props.children}
   </div>
-);
+));
 
 Slide.propTypes = {
   children: PropTypes.node,


### PR DESCRIPTION
This allows to pass forward ref to inner `<div />` element:

```jsx
import { FullPage, Slide } from 'react-full-page-forward-ref';

...
const Home = () => {

	const slideRef= useRef(null);
	
	return (
	<FullPage>
		<Slide ref={slideRef}>
			<Conmponent />
		</Slide>
	</FullPage>
	);
};
```